### PR TITLE
Manage keys for the implementers

### DIFF
--- a/typescript/solver/config/types.ts
+++ b/typescript/solver/config/types.ts
@@ -1,10 +1,10 @@
 import z from "zod";
-import { ethers } from "ethers";
+import { isAddress } from "@ethersproject/address";
 import { chainNames } from "./index.js";
 
 export const addressSchema = z
   .string()
-  .refine((address) => ethers.utils.isAddress(address), {
+  .refine((address) => isAddress(address), {
     message: "Invalid address",
   });
 export const addressValueSchema = z.union([

--- a/typescript/solver/index.ts
+++ b/typescript/solver/index.ts
@@ -8,10 +8,10 @@ import { getMultiProvider } from "./solvers/utils.js";
 
 log.info("🙍 Intent Solver 📝");
 
-const main = () => {
+const main = async () => {
   log.info("Starting...");
 
-  const multiProvider = getMultiProvider();
+  const multiProvider = await getMultiProvider();
 
   // TODO: implement a way to choose different listeners and fillers
   const ecoListener = solvers["eco"].listener.create();
@@ -26,4 +26,4 @@ const main = () => {
   hyperlane7683Listener(hyperlane7683Filler);
 };
 
-main();
+await main();

--- a/typescript/solver/index.ts
+++ b/typescript/solver/index.ts
@@ -6,12 +6,14 @@ import { log } from "./logger.js";
 import * as solvers from "./solvers/index.js";
 import { getMultiProvider } from "./solvers/utils.js";
 
-log.info("🙍 Intent Solver 📝");
 
 const main = async () => {
-  log.info("Starting...");
+  const multiProvider = await getMultiProvider().catch(
+    (error) => (log.error(error.reason ?? error.message), process.exit(1)),
+  );
 
-  const multiProvider = await getMultiProvider();
+  log.info("🙍 Intent Solver 📝");
+  log.info("Starting...");
 
   // TODO: implement a way to choose different listeners and fillers
   const ecoListener = solvers["eco"].listener.create();

--- a/typescript/solver/package.json
+++ b/typescript/solver/package.json
@@ -20,6 +20,7 @@
   "license": "Apache-2.0",
   "description": "",
   "devDependencies": {
+    "@inquirer/prompts": "^7.2.0",
     "@typechain/ethers-v5": "^11.1.2",
     "@types/copyfiles": "^2",
     "copyfiles": "^2.4.1",

--- a/typescript/solver/solvers/utils.ts
+++ b/typescript/solver/solvers/utils.ts
@@ -27,7 +27,7 @@ function privateKeyToSigner(key: string) {
 
   const formattedKey = key.trim().toLowerCase();
   if (isHexString(ensure0x(formattedKey))) {
-    return new NonceKeeperWallet(ensure0x(key)) as NonceKeeperWallet;
+    return new NonceKeeperWallet(ensure0x(formattedKey)) as NonceKeeperWallet;
   }
 
   if (formattedKey.split(" ").length >= 6) {

--- a/typescript/solver/solvers/utils.ts
+++ b/typescript/solver/solvers/utils.ts
@@ -1,23 +1,45 @@
 import { chainMetadata } from "@hyperlane-xyz/registry";
 import { MultiProvider } from "@hyperlane-xyz/sdk";
 import { ensure0x } from "@hyperlane-xyz/utils";
+import { password } from "@inquirer/prompts";
+import { ethers } from "ethers";
 
 import { MNEMONIC, PRIVATE_KEY } from "../config/index.js";
 import { NonceKeeperWallet } from "../NonceKeeperWallet.js";
 
-export function getMultiProvider() {
-  if (!PRIVATE_KEY && !MNEMONIC) {
-    throw new Error("Either a private key or mnemonic must be provided");
-  }
-
+export async function getMultiProvider() {
   const multiProvider = new MultiProvider(chainMetadata);
-  const wallet = (
-    PRIVATE_KEY
-      ? new NonceKeeperWallet(ensure0x(PRIVATE_KEY))
-      : NonceKeeperWallet.fromMnemonic(MNEMONIC!)
-  ) as NonceKeeperWallet;
+  const wallet = await getSigner();
 
   multiProvider.setSharedSigner(wallet);
 
   return multiProvider;
+}
+
+export async function getSigner(): Promise<NonceKeeperWallet> {
+  const key = await retrieveKey();
+  const signer = privateKeyToSigner(key);
+  return signer;
+}
+
+function privateKeyToSigner(key: string): NonceKeeperWallet {
+  if (!key) throw new Error("No private key provided");
+
+  const formattedKey = key.trim().toLowerCase();
+  if (ethers.utils.isHexString(ensure0x(formattedKey)))
+    return new NonceKeeperWallet(ensure0x(key)) as NonceKeeperWallet;
+  else if (formattedKey.split(" ").length >= 6)
+    return NonceKeeperWallet.fromMnemonic(formattedKey) as NonceKeeperWallet;
+  else throw new Error("Invalid private key format");
+}
+
+async function retrieveKey(): Promise<string> {
+  if (PRIVATE_KEY) {
+    return PRIVATE_KEY;
+  } else if (MNEMONIC) {
+    return MNEMONIC;
+  } else
+    return password({
+      message: `Please enter private key or mnemonic.`,
+    });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,191 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/checkbox@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/checkbox@npm:4.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/figures": "npm:^1.0.8"
+    "@inquirer/type": "npm:^3.0.1"
+    ansi-escapes: "npm:^4.3.2"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/09f99ee8d42958f02acd1908f977f134c321d133f00c42676e501939e6d99a8baf27b4dfd94f72f8196d7a1e9188b76ea16dd14176b2f5ad79369ee2aac45826
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@inquirer/confirm@npm:5.1.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/b38187a61c4dd8f1784c6807dbef1022fb476fe36a7fa843b53abfac8919da7d63a1946ae0797b8471318c57aab8549ac3d54f1db1db559b79e4a0a3470f0931
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "@inquirer/core@npm:10.1.1"
+  dependencies:
+    "@inquirer/figures": "npm:^1.0.8"
+    "@inquirer/type": "npm:^3.0.1"
+    ansi-escapes: "npm:^4.3.2"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.2"
+  checksum: 10/4dd9536967391b7bff0135fa81b350ed0c71cb3f9151aea1ea6107512136aa0153efbd4df253ec51656227963421f09d42c8c59773bd13f1ed92f8fabaf14ca3
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@inquirer/editor@npm:4.2.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+    external-editor: "npm:^3.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/1fdd07eebfd447b2a006f6cd2686b6c010d251b46fadd35686f7aae001cbd354866f0c858b878922644e1d450bf54f119a9ce76fe0a8435320a7417c5bf50cc1
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/expand@npm:4.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/81999766350baee07f6eea74a81bac6023e41d4adfc6d27784146c85d21ecd95fbcef1b845a7ae9a906302b9cc25e445a790d769290c20ff8a1bcb959c871dc3
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@inquirer/figures@npm:1.0.8"
+  checksum: 10/0e5e4fbb15e799e818c598fcc3558ef076daf78662149711b046723fd6316381e95f7d5573d6ef0062095ad22c6ac98833033f0948df5c722932107a567fd9c3
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@inquirer/input@npm:4.1.0"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/42c70fc26fb0f34387a64f1b4fc3ce52bbd5487a8cffa5409d3eeb966b800c8f26726c960aa1de0d1b85c68832671d250f456348202ae7cb040c455ae8c18049
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@inquirer/number@npm:3.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/7dca4c0527a04e83e45fa1691811589a97f261f84d7552bff1b0070588939ef52cb3f09b17616c69c1a4c252ae945f335e1cb8251dbfe3d0a3efa32fab1d297c
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/password@npm:4.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+    ansi-escapes: "npm:^4.3.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/9d45e9a2602d516f309511de4b203ff08e7da056321174206e6e81d5835bcfbe39d4c3007bf2f55af7b5e0531993866c783538c5c930ec9e40c85753eeccbb93
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@inquirer/prompts@npm:7.2.0"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.0.3"
+    "@inquirer/confirm": "npm:^5.1.0"
+    "@inquirer/editor": "npm:^4.2.0"
+    "@inquirer/expand": "npm:^4.0.3"
+    "@inquirer/input": "npm:^4.1.0"
+    "@inquirer/number": "npm:^3.0.3"
+    "@inquirer/password": "npm:^4.0.3"
+    "@inquirer/rawlist": "npm:^4.0.3"
+    "@inquirer/search": "npm:^3.0.3"
+    "@inquirer/select": "npm:^4.0.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/c2747c5b831fc891ba54497813dc84b9137b74c6200d5759f86b2a4f646295d3915e739b2e398e933f1209d26eed95e9628cfd352c135995a071ce6ece4b2d45
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/rawlist@npm:4.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/type": "npm:^3.0.1"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/47c33bd1d33859aeaca21e1f54bc306d08c1c78cb974895bfd4370724051c0ef6f6c0c31de6c4859ec603e379d5e5c52839c67db7d691a2919f8b95f6a9b2830
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@inquirer/search@npm:3.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/figures": "npm:^1.0.8"
+    "@inquirer/type": "npm:^3.0.1"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/712f2ff0f7dfaa535d6b2d5dfdc2c202c529808e290887b82a9d082508a5ad7045be170bcb43cd558c05a8e5d7098fddf729dc9c70684865ba23c8d817fae4c1
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@inquirer/select@npm:4.0.3"
+  dependencies:
+    "@inquirer/core": "npm:^10.1.1"
+    "@inquirer/figures": "npm:^1.0.8"
+    "@inquirer/type": "npm:^3.0.1"
+    ansi-escapes: "npm:^4.3.2"
+    yoctocolors-cjs: "npm:^2.1.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/718a6074cb0b69a5d8e3712052dac7a40f7a516cc226a682075f99ab0d48910e5dddb79f21823aa746526edef192429bc3352fc38aeb9590c86cf9b2c3b6e3dc
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@inquirer/type@npm:3.0.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  checksum: 10/af412f1e7541d43554b02199ae71a2039a1bff5dc51ceefd87de9ece55b199682733b28810fb4b6cb3ed4a159af4cc4a26d4bb29c58dd127e7d9dbda0797d8e7
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3585,6 +3770,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: 10/8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -4194,6 +4388,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10/b0ec668fba5eeec575ed2559a0917ba41a6481f49063c8445400e476754e0957ee09e44dc032310f526182b8f1bf25e9d4ed371f74050af7be1383e06bc44952
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^1.0.3":
   version: 1.0.3
   resolution: "check-error@npm:1.0.3"
@@ -4265,6 +4466,13 @@ __metadata:
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
   checksum: 10/2ac8cd2b2f5ec986a3c743935ec85b07bc174d5421a5efc8017e1f146a1cf5f781ae962618f416352103b32c9cd7e203276e8c28241bbe946160cab16149fb68
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
   languageName: node
   linkType: hard
 
@@ -5451,6 +5659,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"external-editor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10/776dff1d64a1d28f77ff93e9e75421a81c062983fd1544279d0a32f563c0b18c52abbb211f31262e2827e48edef5c9dc8f960d06dd2d42d1654443b88568056b
+  languageName: node
+  linkType: hard
+
 "extsprintf@npm:1.3.0":
   version: 1.3.0
   resolution: "extsprintf@npm:1.3.0"
@@ -6169,7 +6388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24":
+"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -7122,6 +7341,13 @@ __metadata:
     multibase: "npm:^0.7.0"
     varint: "npm:^5.0.0"
   checksum: 10/a482d9ba7ed0ad41db22ca589f228e4b7a30207a229a64dfc9888796752314fca00a8d03025fe40d6d73965bbb246f54b73626c5a235463e30c06c7bf7a8785f
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10/d2e4fd2f5aa342b89b98134a8d899d8ef9b0a6d69274c4af9df46faa2d97aeb1f2ce83d867880d6de63643c52386579b99139801e24e7526c3b9b0a6d1e18d6c
   languageName: node
   linkType: hard
 
@@ -8365,7 +8591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -8474,6 +8700,7 @@ __metadata:
     "@hyperlane-xyz/registry": "npm:^4.10.0"
     "@hyperlane-xyz/sdk": "npm:^5.5.0"
     "@hyperlane-xyz/utils": "npm:^5.6.0"
+    "@inquirer/prompts": "npm:^7.2.0"
     "@typechain/ethers-v5": "npm:^11.1.2"
     "@types/copyfiles": "npm:^2"
     chalk: "npm:^5.3.0"
@@ -9005,6 +9232,13 @@ __metadata:
   version: 4.1.0
   resolution: "type-detect@npm:4.1.0"
   checksum: 10/e363bf0352427a79301f26a7795a27718624c49c576965076624eb5495d87515030b207217845f7018093adcbe169b2d119bb9b7f1a31a92bfbb1ab9639ca8dd
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10/f4254070d9c3d83a6e573bcb95173008d73474ceadbbf620dd32d273940ca18734dff39c2b2480282df9afe5d1675ebed5499a00d791758748ea81f61a38961f
   languageName: node
   linkType: hard
 
@@ -9780,6 +10014,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/0d64f2d438e0b555e693b95aee7b2689a12c3be5ac458192a1ce28f542a6e9e59ddfecc37520910c2c88eb1f82a5411260566dba5064e8f9895e76e169e76187
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -9985,6 +10230,13 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "yoctocolors-cjs@npm:2.1.2"
+  checksum: 10/d731e3ba776a0ee19021d909787942933a6c2eafb2bbe85541f0c59aa5c7d475ce86fcb860d5803105e32244c3dd5ba875b87c4c6bf2d6f297da416aa54e556f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes #20 

Adds a new way for the implementer to enter the PK or mnemonic via prompt if env variables are not defined, in a similar fashion to https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/src/utils/keys.ts#L13