### PR TITLE
Fix cold start initial block

### DIFF
--- a/typescript/solver/solvers/hyperlane7683/listener.ts
+++ b/typescript/solver/solvers/hyperlane7683/listener.ts
@@ -44,10 +44,9 @@ export const create = async () => {
   const blocksByChain = await getLastIndexedBlocks();
 
   metadata.originSettlers = originSettlers.map((originSettler) => {
-    if (
-      (blocksByChain[originSettler.chainName]?.blockNumber ?? 0) >=
-      (originSettler.initialBlock ?? 0)
-    ) {
+    const chainBlockNumber = blocksByChain[originSettler.chainName]?.blockNumber;
+
+    if (chainBlockNumber && chainBlockNumber >= (originSettler.initialBlock ?? 0)) {
       return {
         ...originSettler,
         initialBlock: blocksByChain[originSettler.chainName].blockNumber,


### PR DESCRIPTION
Fixes the error
```
[07:01:01.469]: 🙍 Intent Solver 📝
[07:01:01.472]: Starting...
~/intents-framework/typescript/solver/solvers/hyperlane7683/listener.ts:53
        initialBlock: blocksByChain[originSettler.chainName].blockNumber,
                                                             ^


TypeError: Cannot read properties of undefined (reading 'blockNumber')
    at <anonymous> (~/intents-framework/typescript/solver/solvers/hyperlane7683/listener.ts:53:62)
    at Array.map (<anonymous>)
    at Module.create (~/intents-framework/typescript/solver/solvers/hyperlane7683/listener.ts:46:44)
    at main (~/intents-framework/typescript/solver/index.ts:25:5)
    at <anonymous> (~/intents-framework/typescript/solver/index.ts:32:1)
```
