### PR TITLE
fix: Include json files on tsconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN yarn install
 RUN yarn build:solver
 RUN npm install pm2 -g
 
-# Copy the solvers.json configuration file to the dist directory since it's dynamically imported and not processed by TypeScript compiler
-RUN cp ./typescript/solver/config/solvers.json ./typescript/solver/dist/config/solvers.json
-
 # Show current folder structure in logs
 RUN ls -al -R
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN yarn install
 RUN yarn build:solver
 RUN npm install pm2 -g
 
+# Copy the solvers.json configuration file to the dist directory since it's dynamically imported and not processed by TypeScript compiler
+RUN cp ./typescript/solver/config/solvers.json ./typescript/solver/dist/config/solvers.json
+
 # Show current folder structure in logs
 RUN ls -al -R
 

--- a/typescript/solver/tsconfig.json
+++ b/typescript/solver/tsconfig.json
@@ -38,5 +38,5 @@
     "experimentalResolver": true,
     "files": true
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "**/*.json"]
 }


### PR DESCRIPTION
### Description

```ts
// typescript/solver/config/solvers.ts

// Read and parse the JSON file
const solversConfigPath = path.join(__dirname, "solvers.json");
export const solversConfig: Record<string, SolverConfig> = JSON.parse(
  fs.readFileSync(solversConfigPath, "utf-8"),
);
```

The `solvers.json` file is loaded dynamically, but since TypeScript (TSC) ignores JSON files that are not explicitly imported, it is not included in the `dist` folder. As a result, the usage example in the README does not work.

```js
// tsconfig.json

"include": ["*.ts", "**/*.json"]
```

Including JSON files in the `tsconfig` configuration ensures that `solvers.json` is included in the `dist` folder.

<img width="996" alt="Screenshot 2025-03-19 at 5 11 57 PM" src="https://github.com/user-attachments/assets/1842e692-989b-4adf-8159-b6c36536cca5" />


### Drive-by changes

...

### Related issues

Fixes #123 

### Backward compatibility

Yes

### Testing

Manual
